### PR TITLE
fix analogWrite max value not equal maximal duty

### DIFF
--- a/src/analogWrite.cpp
+++ b/src/analogWrite.cpp
@@ -98,7 +98,7 @@ void analogWrite(uint8_t pin, uint32_t value, uint32_t valueMax)
   {
     uint8_t resolution = _analog_write_channels[channel].resolution;
     uint32_t levels = pow(2, resolution);
-    uint32_t duty = ((levels - 1) / valueMax) * min(value, valueMax);
+    uint32_t duty = value ? (levels / valueMax * (min(value, valueMax) + 1)) : value;
 
     // write duty to LEDC
     ledcWrite(channel, duty);


### PR DESCRIPTION
The default ```levels``` is 2^13 =8192. When you set a maximal value of 255 then the ```duty``` is only 8160 and you can see that the build-in LED does not totally power off.