### PR TITLE
Update analogWrite.cpp to heal breaking changes on LEDC API.

### DIFF
--- a/src/analogWrite.cpp
+++ b/src/analogWrite.cpp
@@ -41,8 +41,10 @@ int analogWriteChannel(uint8_t pin)
       {
         _analog_write_channels[i].pin = pin;
         channel = i;
-        ledcSetup(channel, _analog_write_channels[i].frequency, _analog_write_channels[i].resolution);
-        ledcAttachPin(pin, channel);
+        // ledcSetup and ledcAttachedPin are removed from Arduino 3.0 and newer - instead, letdcAttach is being used.
+        // ledcSetup(channel, _analog_write_channels[i].frequency, _analog_write_channels[i].resolution);
+        // ledcAttachPin(pin, channel);
+        ledcAttach(pin, _analog_write_channels[i].frequency, _analog_write_channels[i].resolution);
         break;
       }
     }


### PR DESCRIPTION
**The LEDC API has been changed.**
ledcAttach used to set up the LEDC pin (merged ledcSetup and ledcAttachPin functions)

For more information, see
[1] https://github.com/espressif/arduino-esp32/blob/master/docs/en/api/ledc.rst (23.08.2024)

Changes were tested on ESP32-WROOM-32 hardware.

fix for https://github.com/erropix/ESP32_AnalogWrite/issues/15